### PR TITLE
use global variable instead of returning ref to local

### DIFF
--- a/track_oracle/core/kwiver_io_base.txx
+++ b/track_oracle/core/kwiver_io_base.txx
@@ -30,17 +30,11 @@ typedef char (&no_io_type)[2];
 typedef char yes_io_type;
 
 struct proxy{ template <typename U> proxy(const U&); };
-# if defined(_MSC_VER)
-#  pragma warning( push )
-#  pragma warning( disable : 4172 ) /* returning address of local variable */
-# endif
 
-no_io_type operator>>( const proxy&, const proxy& ) { char tmp[2]; no_io_type not_used(tmp); return not_used; }
-no_io_type check( no_io_type ) { char tmp[2]; no_io_type not_used(tmp); return not_used; }
+char tmp[2]; no_io_type not_used(tmp);
+no_io_type operator>>( const proxy&, const proxy& ) { return not_used; }
+no_io_type check( no_io_type ) { return not_used; }
 
-# if defined(_MSC_VER)
-#  pragma warning( pop )
-# endif
 
 template <typename U> yes_io_type check( const U& );
 


### PR DESCRIPTION
This avoids the return of a local reference and does not produce a warning without needing to disable the warning.  This is better because other non-MSVC compilers may have their own warnings about this.  Global variables are not ideal either, but at least it's in an anonymous namespace.  